### PR TITLE
Changed extension.json

### DIFF
--- a/DiscordNotifications/extension.json
+++ b/DiscordNotifications/extension.json
@@ -9,12 +9,12 @@
 		"DiscordNotifications": "DiscordNotificationsCore.php"
 	},
 	"Hooks": {
-		"ArticleSaveComplete": [
+		"PageContentSaveComplete": [
 			[
 				"DiscordNotifications::discord_article_saved"
 			]
 		],
-		"ArticleInsertComplete": [
+		"PageContentInsertComplete": [
 			[
 				"DiscordNotifications::discord_article_inserted"
 			]


### PR DESCRIPTION
I've replaced `ArticleSaveComplete` and the `ArticleInsertComplete` hooks with `PageContentSaveComplete` and `PageContentInsertComplete`.

Even though it's deprecated I haven't replaced `AddNewAccount` yet because it's still seem to be functioning.